### PR TITLE
Make use of default None argument in calls to get_value

### DIFF
--- a/integration/test_component.py
+++ b/integration/test_component.py
@@ -93,15 +93,15 @@ def test_handle_invoke_method(workflow) -> None:
     # Run the workflow to validate outputs.
     workflow.run()
 
-    assert time.get_value(None).is_valid
-    assert distance.get_value(None).is_valid
+    assert time.get_value().is_valid
+    assert distance.get_value().is_valid
 
     # Act
     component.invoke_method("Reload Input Values")
 
     # Verify
-    assert time.get_value(None).is_valid is False
-    assert distance.get_value(None).is_valid is False
+    assert time.get_value().is_valid is False
+    assert distance.get_value().is_valid is False
 
 
 def test_handle_downloading_values_from_local_component(workflow) -> None:
@@ -128,15 +128,15 @@ def test_can_download_variables(workflow) -> None:
 
     speed.set_value(acvi.VariableState(value=acvi.RealValue(20.0), is_valid=True))
     weight.set_value(acvi.VariableState(value=acvi.RealValue(2750.5), is_valid=True))
-    assert speed.get_value(None).value == 20.0
-    assert weight.get_value(None).value == 2750.5
+    assert speed.get_value().value == 20.0
+    assert weight.get_value().value == 2750.5
 
     # Act
     component.download_values()
 
     # Verify
-    assert speed.get_value(None).value == 60
-    assert weight.get_value(None).value == 3200
+    assert speed.get_value().value == 60
+    assert weight.get_value().value == 3200
 
 
 def test_invalidate_component(workflow) -> None:
@@ -148,14 +148,14 @@ def test_invalidate_component(workflow) -> None:
     workflow.run()
 
     # Make sure outputs are valid.
-    assert variables["boolOut"].get_value(None).is_valid
-    assert variables["realOut"].get_value(None).is_valid
+    assert variables["boolOut"].get_value().is_valid
+    assert variables["realOut"].get_value().is_valid
 
     component.invalidate()
 
     # Verify outputs are invalidated.
-    assert not variables["boolOut"].get_value(None).is_valid
-    assert not variables["realOut"].get_value(None).is_valid
+    assert not variables["boolOut"].get_value().is_valid
+    assert not variables["realOut"].get_value().is_valid
 
 
 def test_can_set_component_properties(workflow) -> None:


### PR DESCRIPTION
Make use of default argument and get rid of None value when using `get_value` method in integration tests.
