### PR TITLE
ci: fix ``ansys/actions/doc-deploy-dev`` and ``ansys/actions/doc-deploy-stable``

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,12 +1,14 @@
 version: 2
 updates:
 - package-ecosystem: "pip" # See documentation for possible values
-  directory: "pyproject.toml" # Location of package manifests
+  directory: "/"
   schedule:
     interval: "weekly"
   labels:
     - "maintenance"
     - "dependencies"
+  commit-message:
+      prefix: "build"
 
 - package-ecosystem: "github-actions"
   directory: "/"

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -134,6 +134,8 @@ jobs:
         with:
           cname: ${{ env.DOCUMENTATION_CNAME }}
           token: ${{ secrets.GITHUB_TOKEN }}
+          bot-user: ${{ secrets.PYANSYS_CI_BOT_USERNAME }}
+          bot-email: ${{ secrets.PYANSYS_CI_BOT_EMAIL }}
 
 
   release:
@@ -165,5 +167,7 @@ jobs:
       - name: "Deploy the stable documentation"
         uses: ansys/actions/doc-deploy-stable@v8
         with:
-            cname: ${{ env.DOCUMENTATION_CNAME }}
-            token: ${{ secrets.GITHUB_TOKEN }}
+          cname: ${{ env.DOCUMENTATION_CNAME }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          bot-user: ${{ secrets.PYANSYS_CI_BOT_USERNAME }}
+          bot-email: ${{ secrets.PYANSYS_CI_BOT_EMAIL }}


### PR DESCRIPTION
CICD is failing due to missing arguments in ``ansys/actions/doc-deploy-dev`` and ``ansys/actions/doc-deploy-stable``