### PR TITLE
chore: support Python 3.13 and drop support for Python 3.9

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -39,7 +39,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.10', '3.11', '3.12', '3.13']
         # Only perform wheelhouse builds for Windows and macOS when releasing
         should-release:
           - ${{ github.event_name == 'push' && contains(github.ref, 'refs/tags') }}
@@ -63,7 +63,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.10', '3.11', '3.12', '3.13']
         should-release:
           - ${{ github.event_name == 'push' && contains(github.ref, 'refs/tags') }}
     steps:

--- a/doc/source/contributing/index.rst
+++ b/doc/source/contributing/index.rst
@@ -13,7 +13,7 @@ The following contribution information is specific to Ansys ModelCenter Workflow
 Developer installation
 -----------------------
 Installing Ansys ModelCenter Workflow in developer mode allows you to modify the
-source and enhance it. This package supports Python 3.9 through 3.12 on
+source and enhance it. This package supports Python 3.10 through 3.13 on
 Linux, macOS, and Windows.
 
 For a local development version, you can create a clean virtual environment with

--- a/doc/source/getting_started/index.rst
+++ b/doc/source/getting_started/index.rst
@@ -3,7 +3,7 @@
 Getting started
 ===============
 
-Ansys ModelCenter Workflow supports Python 3.9 through 3.12 on Linux, macOS, and Windows.
+Ansys ModelCenter Workflow supports Python 10 through 3.13 on Linux, macOS, and Windows.
 This library has two installation modes: user and developer. The following instructions
 assume that you want to install Ansys ModelCenter Workflow in user mode. If you want to
 contribute to the development of Ansys ModelCenter Workflow, you must install it in developer

--- a/doc/source/getting_started/index.rst
+++ b/doc/source/getting_started/index.rst
@@ -3,7 +3,7 @@
 Getting started
 ===============
 
-Ansys ModelCenter Workflow supports Python 10 through 3.13 on Linux, macOS, and Windows.
+Ansys ModelCenter Workflow supports Python 3.10 through 3.13 on Linux, macOS, and Windows.
 This library has two installation modes: user and developer. The following instructions
 assume that you want to install Ansys ModelCenter Workflow in user mode. If you want to
 contribute to the development of Ansys ModelCenter Workflow, you must install it in developer

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "ansys-modelcenter-workflow"
 version = "0.1.dev0"
 description = "A python wrapper for ModelCenter Desktop"
 readme = "README.rst"
-requires-python = ">=3.9,<4"
+requires-python = ">=3.10,<4"
 license = {file = "LICENSE"}
 authors = [{name = "ANSYS, Inc.", email = "pyansys.core@ansys.com"}]
 maintainers = [{name = "ANSYS, Inc.", email = "pyansys.core@ansys.com"}]
@@ -22,10 +22,10 @@ classifiers = [
     "Operating System :: Microsoft :: Windows :: Windows 11",
     "Operating System :: Microsoft :: Windows :: Windows Server 2003",
     "Operating System :: Microsoft :: Windows :: Windows Server 2008",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
 ]
 dependencies = [
     "ansys-platform-instancemanagement>=1.1.1",


### PR DESCRIPTION
Active support for Python 3.13 and dropping Python 3.9